### PR TITLE
Add `Icon` widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,16 @@ All notable changes to agape will be documented in this file.
 
 ## [unreleased]
 
-### Added
+### Features
 
 - Support for image rendering.
 - Svg rendering using the `resvg` crate.
 
-#### Widgets
+#### New widgets
 
-- `Image`
-- `Svg`
+- `Image`: Draw images to the screen
+- `Svg`: Draw SVGs to the screen
+- `Icon`: Idiomatic wrapper for `Svg`
 
 ### Changed
 
@@ -25,7 +26,7 @@ All notable changes to agape will be documented in this file.
 
 ## 0.2.0 - 2025-07-17
 
-### Added
+### Features
 
 - Added `Resources` struct to share global resources
 - Repeat syntax, `hstack![widget;10]`, to `hstack!` and `vstack!` macros
@@ -35,7 +36,7 @@ All notable changes to agape will be documented in this file.
 - `BoxStyle`, which contains common styling for all widgets
 - Added event systems, i.e. systems that run when specific events are emitted
 
-### Changed
+### Changes
 
 - Systems now have a `&mut Resources` instead of the previous `&mut Context`
 - Most of the functionality, like layout and state, is now handled in systems

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,15 +85,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "aligned-vec"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,56 +130,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "anstream"
-version = "0.6.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
-dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
-dependencies = [
- "anstyle",
- "once_cell_polyfill",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -474,12 +415,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
-name = "colorchoice"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
-
-[[package]]
 name = "com"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,42 +616,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
-name = "env_filter"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -747,8 +646,6 @@ version = "0.3.0"
 dependencies = [
  "agape",
  "dotenv",
- "env_logger 0.11.8",
- "pretty_env_logger",
 ]
 
 [[package]]
@@ -1043,22 +940,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "hexf-parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
-
-[[package]]
-name = "humantime"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
 name = "image"
@@ -1127,53 +1012,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
-dependencies = [
- "hermit-abi 0.5.2",
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "is_terminal_polyfill"
-version = "1.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
 name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
-]
-
-[[package]]
-name = "jiff"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
 ]
 
 [[package]]
@@ -1788,12 +1632,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
-name = "once_cell_polyfill"
-version = "1.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
-
-[[package]]
 name = "orbclient"
 version = "0.3.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1919,7 +1757,7 @@ checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi 0.4.0",
+ "hermit-abi",
  "pin-project-lite",
  "rustix",
  "tracing",
@@ -1931,21 +1769,6 @@ name = "pollster"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22686f4785f02a4fcc856d3b3bb19bf6c8160d103f7a99cc258bddd0251dc7f2"
-
-[[package]]
-name = "portable-atomic"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
-dependencies = [
- "portable-atomic",
-]
 
 [[package]]
 name = "ppv-lite86"
@@ -1961,16 +1784,6 @@ name = "presser"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
-
-[[package]]
-name = "pretty_env_logger"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "865724d4dbe39d9f3dd3b52b88d859d66bcb2d6a0acfd5ea68a65fb66d4bdc1c"
-dependencies = [
- "env_logger 0.10.2",
- "log",
-]
 
 [[package]]
 name = "proc-macro-crate"
@@ -2206,35 +2019,6 @@ checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
  "bitflags 2.8.0",
 ]
-
-[[package]]
-name = "regex"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "renderdoc-sys"
@@ -2819,12 +2603,6 @@ dependencies = [
  "unicode-vo",
  "xmlwriter",
 ]
-
-[[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "v_frame"

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ fn main() -> Result<(), agape::Error> {
 }
 ```
 
+## Features
+
+- `feather-icons`: Embeds the whole [feather icons](https://feathericons.com/) library at compile time.
+
 ## Support
 
 | Platform | Status |

--- a/agape/Cargo.toml
+++ b/agape/Cargo.toml
@@ -10,6 +10,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[features]
+feather-icons = []
+
 [dependencies]
 image.workspace = true
 thiserror.workspace = true

--- a/agape/src/widgets/icon.rs
+++ b/agape/src/widgets/icon.rs
@@ -1,0 +1,29 @@
+use crate::widgets::{RenderBox, Svg, Widget};
+use agape_core::GlobalId;
+
+#[derive(Debug)]
+pub struct Icon {
+    id: GlobalId,
+    svg: Svg,
+}
+
+impl Icon {
+    /// Create an icon from svg bytes.
+    pub fn svg_bytes(data: &[u8]) -> crate::Result<Self> {
+        let svg = Svg::from_data(data)?;
+        Ok(Self {
+            id: GlobalId::new(),
+            svg,
+        })
+    }
+}
+
+impl Widget for Icon {
+    fn id(&self) -> GlobalId {
+        self.id
+    }
+
+    fn build(&self) -> RenderBox {
+        self.svg.build()
+    }
+}

--- a/agape/src/widgets/icon.rs
+++ b/agape/src/widgets/icon.rs
@@ -6,7 +6,7 @@ use agape_core::GlobalId;
 pub mod feather_icons {
     use agape_macros::include_icons;
 
-    include_icons! {"./agape/icons/feather-icons"}
+    include_icons!("./agape/icons/feather-icons");
 }
 
 #[derive(Debug)]

--- a/agape/src/widgets/icon.rs
+++ b/agape/src/widgets/icon.rs
@@ -1,6 +1,14 @@
 use crate::widgets::{RenderBox, Svg, Widget};
 use agape_core::GlobalId;
 
+/// Contains all the icons from the [feather icons](https://feathericons.com/) library.
+#[cfg(feature = "feather-icons")]
+pub mod feather_icons {
+    use agape_macros::include_icons;
+
+    include_icons! {"./agape/icons/feather-icons"}
+}
+
 #[derive(Debug)]
 pub struct Icon {
     id: GlobalId,
@@ -9,7 +17,7 @@ pub struct Icon {
 
 impl Icon {
     /// Create an icon from svg bytes.
-    pub fn svg_bytes(data: &[u8]) -> crate::Result<Self> {
+    pub fn bytes(data: &[u8]) -> crate::Result<Self> {
         let svg = Svg::from_data(data)?;
         Ok(Self {
             id: GlobalId::new(),

--- a/agape/src/widgets/mod.rs
+++ b/agape/src/widgets/mod.rs
@@ -3,7 +3,7 @@
 //! and [`VStack`], and the list goes on. Every widget must implement the [`Widget`] trait.
 mod button;
 mod hstack;
-mod icon;
+pub mod icon;
 pub mod image;
 mod rect;
 mod svg;

--- a/agape/src/widgets/mod.rs
+++ b/agape/src/widgets/mod.rs
@@ -3,6 +3,7 @@
 //! and [`VStack`], and the list goes on. Every widget must implement the [`Widget`] trait.
 mod button;
 mod hstack;
+mod icon;
 pub mod image;
 mod rect;
 mod svg;
@@ -27,6 +28,7 @@ use winit::keyboard;
 
 pub use button::Button;
 pub use hstack::*;
+pub use icon::Icon;
 pub use image::Image;
 pub use rect::*;
 pub use svg::Svg;

--- a/agape_macros/src/lib.rs
+++ b/agape_macros/src/lib.rs
@@ -20,21 +20,22 @@ pub fn hex(item: TokenStream) -> TokenStream {
     }
 }
 
-/// This macro does the very tedius job of defining a function for each icon in a
+// TODO: split and test this
+/// This macro does the very tedious job of defining a function for each icon in a
 /// directory. The icon must be in svg format, all non-svg files in the directory will be ignored.
 ///
-/// Files that start with reserved keywords will be prefixed with `_`.
-/// eg `box.svg -> _box()`
+/// Files that start with reserved keywords will be prefixed with an underscore,
+/// e.g. `box.svg -> _box()`
 #[proc_macro]
 pub fn include_icons(dir: TokenStream) -> TokenStream {
     let dir_name = dir.to_string().replace("\"", "");
     let path = Path::new(&dir_name);
 
     let mut icons: Vec<proc_macro2::TokenStream> = vec![];
-
     match fs::read_dir(path) {
         Ok(entries) => {
             for entry in entries {
+                // dbg!(&entry);
                 // TODO handle these unwraps
                 let file = entry.unwrap();
                 let entry_type = file.file_type().unwrap();
@@ -63,7 +64,9 @@ pub fn include_icons(dir: TokenStream) -> TokenStream {
 
                 // Filter reserved keywords
                 match file_name.as_str() {
-                    "box" | "move" | "type" | "let" => file_name = format!("_{file_name}"),
+                    "box" | "move" | "type" | "let" | "struct" => {
+                        file_name = format!("_{file_name}")
+                    }
                     _ => {}
                 }
 
@@ -74,7 +77,7 @@ pub fn include_icons(dir: TokenStream) -> TokenStream {
 
                 icons.push(quote! {
                     pub fn #fn_name() -> crate::widgets::icon::Icon{
-                        crate::widgets::icon::Icon::bytes(#svg_data_literal)
+                        crate::widgets::icon::Icon::bytes(#svg_data_literal).unwrap()
                     }
                 });
             }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -5,10 +5,8 @@ version.workspace = true
 publish = false
 
 [dev-dependencies]
-agape = { path = "../agape" }
-env_logger = "0.11.8"
+agape = { path = "../agape", features = ["feather-icons"] }
 dotenv = "0.15.0"
-pretty_env_logger = "0.5.0"
 
 
 [[example]]

--- a/examples/vstack.rs
+++ b/examples/vstack.rs
@@ -1,4 +1,4 @@
-use agape::widgets::*;
+use agape::widgets::{icon::feather_icons, *};
 use agape::{App, hstack, vstack};
 
 fn main() -> Result<(), agape::Error> {
@@ -9,7 +9,7 @@ fn main() -> Result<(), agape::Error> {
         image,
         Text::new("PARTYNEXTDOOR").font_size(24),
         hstack!{
-            svg,
+            feather_icons::calendar(),
             Text::new("2013").font_size(12)
         }
         .spacing(8)

--- a/examples/vstack.rs
+++ b/examples/vstack.rs
@@ -3,7 +3,6 @@ use agape::{App, hstack, vstack};
 
 fn main() -> Result<(), agape::Error> {
     let image = Image::open("./examples/assets/PARTYNEXTDOOR Album Cover.jpg")?.fixed(250.0, 250.0);
-    let svg = Svg::open("agape/icons/feather-icons/calendar.svg")?;
 
     let vstack = vstack! {
         image,


### PR DESCRIPTION
Adds a new `Icon` widget, which is just an idiomatic wrapper of the `Svg` widget. Also adds the entire feather icons library behind a feature flag (`feather-icons`), for convenience. 